### PR TITLE
fix tsx & javascript queries

### DIFF
--- a/queries/_javascript.scm
+++ b/queries/_javascript.scm
@@ -1,0 +1,1 @@
+; See https://github.com/helix-editor/helix/blob/master/runtime/queries/ecma/README.md for more info.

--- a/queries/_jsx.scm
+++ b/queries/_jsx.scm
@@ -1,0 +1,1 @@
+; See https://github.com/helix-editor/helix/blob/master/runtime/queries/ecma/README.md for more info.

--- a/queries/ecma.scm
+++ b/queries/ecma.scm
@@ -1,9 +1,6 @@
 (function_declaration
   body: (_) @function.inside) @function.around
 
-(function
-  body: (_) @function.inside) @function.around
-
 (arrow_function
   body: (_) @function.inside) @function.around
 


### PR DESCRIPTION
Two fixes for javascript and tsx:
- add missing _jsx.scm and _javascript.scm files
Fixes error `meow-tree-sitter--get-query: No default query found for "_jsx"!`

- remove invalid `function` node 
Fixes error `meow-tree-sitter--get-nodes-of-type: Query pattern is malformed: "Node type error at"`

I'm not sure why the `function` node exists in helix but not in emacs, function selection still works with the `function_declaration` node