### PR TITLE
fix(queries): remove c-sharp `record_struct_declaration` query

### DIFF
--- a/queries/c-sharp.scm
+++ b/queries/c-sharp.scm
@@ -5,7 +5,6 @@
   (enum_declaration body: (_) @class.inside)
   (delegate_declaration)
   (record_declaration body: (_) @class.inside)
-  (record_struct_declaration body: (_) @class.inside)
 ] @class.around
 
 (constructor_declaration body: (_) @function.inside) @function.around


### PR DESCRIPTION
Since `record_struct_declaration` query was removed in https://github.com/tree-sitter/tree-sitter-c-sharp/commit/4b5502f7de37769c39e5d8e3766ee7b142d31e20# currently it causes node type error on every `meow-tree-sitter--get-nodes` invocation.